### PR TITLE
Added Mistral namespace to NOVAL

### DIFF
--- a/xcsp/xml/XMLParser_libxml2.hh
+++ b/xcsp/xml/XMLParser_libxml2.hh
@@ -61,7 +61,7 @@ namespace CSPXMLParser
   public:
     typedef unsigned char Byte;
 
-    static const int npos=NOVAL;
+    static const int npos=Mistral::NOVAL;
 
     UTF8String()
     {


### PR DESCRIPTION
xcsp binaires build failed with gcc 4.8 on ubuntu 14  with error:
In file included from xsolve.cpp:26:0:
xml/XMLParser_libxml2.hh: At global scope:
xml/XMLParser_libxml2.hh:64:27: error: ‘NOVAL’ was not declared in this scope
     static const int npos=NOVAL;
                           ^
xml/XMLParser_libxml2.hh:64:27: note: suggested alternative:
In file included from ../src/include/mistral_global.hpp:37:0,
                 from xml/XMLParser_libxml2.hh:34,
                 from xsolve.cpp:26:
../src/include/mistral_structure.hpp:67:11: note:   ‘Mistral::NOVAL’
 const int NOVAL = (int)((~(unsigned int)0)/2);
           ^

